### PR TITLE
Convert suggestions to annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Next Video Annotations Mapper (next-video-annotations-mapper)
 
-Next Video Annotations Mapper transforms the annotations as received from Next within the video content to an internal format acceptable for further processing and storing on Neo4J.
+Next Video Annotations Mapper transforms the metadata as received from Next within the video content to an internal format acceptable for further processing and storing on Neo4J.
 Video content from Next is got from the Kafka(-bridge) queue where the application listens on topic NativeCmsPublicationEvents, the annotations and video uuid information is
 used for transformation, resulting content being put back to Kafka(-bridge) on V1ConceptAnnotations topic.
 
@@ -185,7 +185,7 @@ Body:
 ```
 {
   "uuid": "e2290d14-7e80-4db8-a715-949da4de9a07",
-  "suggestions": [
+  "annotations": [
     {
       "thing": {
         "id": "http://api.ft.com/things/d969d76e-f8f4-34ae-bc38-95cfd0884740",

--- a/annotations.go
+++ b/annotations.go
@@ -7,13 +7,13 @@ const (
 	defaultRelevanceScore  = 0.9
 )
 
-// ConceptSuggestion models the suggestion as it will be written on the queue
-type ConceptSuggestion struct {
+// ConceptAnnotation models the annotation as it will be written on the queue
+type ConceptAnnotation struct {
 	UUID        string       `json:"uuid"`
-	Suggestions []suggestion `json:"suggestions"`
+	Annotations []annotation `json:"annotations"`
 }
 
-type suggestion struct {
+type annotation struct {
 	Thing      thing        `json:"thing"`
 	Provenance []provenance `json:"provenances,omitempty"`
 }
@@ -54,21 +54,21 @@ type annsContext struct {
 	transactionID string
 }
 
-func createAnnotations(nextAnns []annotation, context annsContext) ConceptSuggestion {
-	var suggestions = make([]suggestion, 0)
+func createAnnotations(nextAnns []tag, context annsContext) ConceptAnnotation {
+	var annotations = make([]annotation, 0)
 	for _, nextAnn := range nextAnns {
-		suggestions = append(suggestions, newAnnotation(nextAnn))
+		annotations = append(annotations, newAnnotation(nextAnn))
 	}
 
-	return ConceptSuggestion{UUID: context.videoUUID, Suggestions: suggestions}
+	return ConceptAnnotation{UUID: context.videoUUID, Annotations: annotations}
 }
 
-func newAnnotation(nextAnn annotation) suggestion {
+func newAnnotation(nextAnn tag) annotation {
 	t := thing{
 		ID:        nextAnn.thingID,
 		Predicate: nextAnn.predicate,
 		Types:     []string{},
 	}
 
-	return suggestion{Thing: t, Provenance: provenances}
+	return annotation{Thing: t, Provenance: provenances}
 }

--- a/annotations_test.go
+++ b/annotations_test.go
@@ -14,49 +14,49 @@ func init() {
 func TestAnnotationsCreation(t *testing.T) {
 	assert := assert.New(t)
 	tests := []struct {
-		anns       []annotation
-		expectedCs ConceptSuggestion
+		tags       []tag
+		expectedCs ConceptAnnotation
 	}{
 		{
-			[]annotation{
+			[]tag{
+				newTestTag("id1", "isClassifiedBy"),
+				newTestTag("id2", "about"),
+			},
+			newConceptAnnotation(videoUUID,
 				newTestAnnotation("id1", "isClassifiedBy"),
 				newTestAnnotation("id2", "about"),
-			},
-			newConceptSuggestion(videoUUID,
-				newSuggestion("id1", "isClassifiedBy"),
-				newSuggestion("id2", "about"),
 			),
 		},
 		{
-			[]annotation{},
-			ConceptSuggestion{videoUUID, make([]suggestion, 0)},
+			[]tag{},
+			ConceptAnnotation{videoUUID, make([]annotation, 0)},
 		},
 	}
 
 	context := annsContext{videoUUID: videoUUID}
 	for _, test := range tests {
-		actualConceptSuggestion := createAnnotations(test.anns, context)
-		assert.Equal(test.expectedCs, actualConceptSuggestion, "Wrong conceptSuggestion. Input anns: [%v]", test.anns)
+		actualConceptAnnotations := createAnnotations(test.tags, context)
+		assert.Equal(test.expectedCs, actualConceptAnnotations, "Wrong conceptAnnotation. Input anns: [%v]", test.tags)
 	}
 }
 
-func newTestAnnotation(thingID string, predicate string) annotation {
-	return annotation{
+func newTestTag(thingID string, predicate string) tag {
+	return tag{
 		thingID:   thingID,
 		predicate: predicate,
 	}
 }
 
-func newSuggestion(thingID string, predicate string) suggestion {
+func newTestAnnotation(thingID string, predicate string) annotation {
 	t := thing{
 		ID:        thingID,
 		Predicate: predicate,
 		Types:     []string{},
 	}
 
-	return suggestion{Thing: t, Provenance: provenances}
+	return annotation{Thing: t, Provenance: provenances}
 }
 
-func newConceptSuggestion(videoUUID string, suggestions ...suggestion) ConceptSuggestion {
-	return ConceptSuggestion{videoUUID, suggestions}
+func newConceptAnnotation(videoUUID string, annotations ...annotation) ConceptAnnotation {
+	return ConceptAnnotation{videoUUID, annotations}
 }

--- a/mapper.go
+++ b/mapper.go
@@ -20,7 +20,7 @@ type videoMapper struct {
 	unmarshalled map[string]interface{}
 }
 
-type annotation struct {
+type tag struct {
 	thingID   string
 	predicate string
 }
@@ -47,9 +47,9 @@ func (vm *videoMapper) mapNextVideoAnnotations() ([]byte, string, error) {
 		logger.videoMapEvent(vm.tid, videoUUID, fmt.Sprintf("No annotation could be retrieved for Next video: [%s]", vm.strContent))
 	}
 
-	conceptSuggestion := createAnnotations(annotations, annsContext{videoUUID: videoUUID, transactionID: vm.tid})
+	conceptAnnotations := createAnnotations(annotations, annsContext{videoUUID: videoUUID, transactionID: vm.tid})
 
-	marshalledPubEvent, err := json.Marshal(conceptSuggestion)
+	marshalledPubEvent, err := json.Marshal(conceptAnnotations)
 	if err != nil {
 		logger.videoEvent(vm.tid, videoUUID, "Error marshalling processed annotations")
 		return nil, videoUUID, err
@@ -58,8 +58,8 @@ func (vm *videoMapper) mapNextVideoAnnotations() ([]byte, string, error) {
 	return marshalledPubEvent, videoUUID, nil
 }
 
-func (vm *videoMapper) retrieveAnnotations(nextAnnsArray []map[string]interface{}, videoUUID string) []annotation {
-	var annotations = make([]annotation, 0)
+func (vm *videoMapper) retrieveAnnotations(nextAnnsArray []map[string]interface{}, videoUUID string) []tag {
+	var annotations = make([]tag, 0)
 	for _, ann := range nextAnnsArray {
 		thingID, err := getRequiredStringField(annotationIDField, ann)
 		if err != nil {
@@ -79,7 +79,7 @@ func (vm *videoMapper) retrieveAnnotations(nextAnnsArray []map[string]interface{
 			continue
 		}
 
-		ann := annotation{
+		ann := tag{
 			thingID:   thingID,
 			predicate: predicate,
 		}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -30,7 +30,7 @@ func TestBuildAnnotations(t *testing.T) {
 	vm := videoMapper{}
 	tests := []struct {
 		nextAnns     []map[string]interface{}
-		expectedAnns []annotation
+		expectedAnns []tag
 	}{
 		{
 			[]map[string]interface{}{
@@ -38,7 +38,7 @@ func TestBuildAnnotations(t *testing.T) {
 				newNextAnnotation("http://api.ft.com/things/d969d76e-f8f4-34ae-bc38-123456666677", "unknown_predicate_id"),
 				newNextAnnotation("http://api.ft.com/things/d969d76e-f8f4-34ae-bc38-123456666677", "http://www.ft.com/ontology/annotation/mentions"),
 			},
-			[]annotation{
+			[]tag{
 				{"http://api.ft.com/things/d969d76e-f8f4-34ae-bc38-95cfd0884740", "isClassifiedBy"},
 				{"http://api.ft.com/things/d969d76e-f8f4-34ae-bc38-123456666677", "mentions"},
 			},
@@ -47,13 +47,13 @@ func TestBuildAnnotations(t *testing.T) {
 			[]map[string]interface{}{
 				newNextAnnotation(nil, "http://www.ft.com/ontology/annotation/mentions"),
 			},
-			[]annotation{},
+			[]tag{},
 		},
 		{
 			[]map[string]interface{}{
 				newNextAnnotation("http://api.ft.com/things/d969d76e-f8f4-34ae-bc38-95cfd0884740", nil),
 			},
-			[]annotation{},
+			[]tag{},
 		},
 	}
 	for _, test := range tests {
@@ -72,8 +72,8 @@ func TestMapNextVideoAnnotationsHappyFlow(t *testing.T) {
 	}{
 		{
 			"next-video-input.json",
-			newStringConceptSuggestion(t, "e2290d14-7e80-4db8-a715-949da4de9a07",
-				[]suggestion{newSuggestion("http://api.ft.com/things/71a5efa5-e6e0-3ce1-9190-a7eac8bef325", "isClassifiedBy")},
+			newStringConceptAnnotation(t, "e2290d14-7e80-4db8-a715-949da4de9a07",
+				[]annotation{newTestAnnotation("http://api.ft.com/things/71a5efa5-e6e0-3ce1-9190-a7eac8bef325", "isClassifiedBy")},
 			),
 			"e2290d14-7e80-4db8-a715-949da4de9a07",
 			false,
@@ -262,12 +262,12 @@ func readContent(fileName string) (map[string]interface{}, error) {
 	return result, nil
 }
 
-func newStringConceptSuggestion(t *testing.T, videoUUID string, s []suggestion) string {
-	var suggestions = make([]suggestion, 0)
+func newStringConceptAnnotation(t *testing.T, videoUUID string, s []annotation) string {
+	var annotations = make([]annotation, 0)
 	if s != nil {
-		suggestions = append(suggestions, s...)
+		annotations = append(annotations, s...)
 	}
-	cs := newConceptSuggestion(videoUUID, suggestions...)
+	cs := newConceptAnnotation(videoUUID, annotations...)
 	marshalledContent, err := json.Marshal(cs)
 	if err != nil {
 		assert.Fail(t, err.Error())

--- a/queuehandler.go
+++ b/queuehandler.go
@@ -14,7 +14,7 @@ import (
 const (
 	nextVideoOrigin  = "http://cmdb.ft.com/systems/next-video-editor"
 	dateFormat       = "2006-01-02T03:04:05.000Z0700"
-	generatedMsgType = "concept-suggestions"
+	generatedMsgType = "concept-annotations"
 )
 
 type queueHandler struct {

--- a/queuehandler_test.go
+++ b/queuehandler_test.go
@@ -31,8 +31,8 @@ func TestQueueConsume(t *testing.T) {
 			nextVideoOrigin,
 			"1234",
 			true,
-			newStringConceptSuggestion(t, "e2290d14-7e80-4db8-a715-949da4de9a07",
-				[]suggestion{newSuggestion("http://api.ft.com/things/71a5efa5-e6e0-3ce1-9190-a7eac8bef325", "isClassifiedBy")},
+			newStringConceptAnnotation(t, "e2290d14-7e80-4db8-a715-949da4de9a07",
+				[]annotation{newTestAnnotation("http://api.ft.com/things/71a5efa5-e6e0-3ce1-9190-a7eac8bef325", "isClassifiedBy")},
 			),
 		},
 		{
@@ -68,7 +68,7 @@ func TestQueueConsume(t *testing.T) {
 			nextVideoOrigin,
 			"1234",
 			true,
-			newStringConceptSuggestion(t, "e2290d14-7e80-4db8-a715-949da4de9a07", nil),
+			newStringConceptAnnotation(t, "e2290d14-7e80-4db8-a715-949da4de9a07", nil),
 		},
 	}
 

--- a/servicehandler_test.go
+++ b/servicehandler_test.go
@@ -26,8 +26,8 @@ func TestMapRequest(t *testing.T) {
 	}{
 		{
 			"next-video-input.json",
-			newStringConceptSuggestion(t, "e2290d14-7e80-4db8-a715-949da4de9a07",
-				[]suggestion{newSuggestion("http://api.ft.com/things/71a5efa5-e6e0-3ce1-9190-a7eac8bef325", "isClassifiedBy")},
+			newStringConceptAnnotation(t, "e2290d14-7e80-4db8-a715-949da4de9a07",
+				[]annotation{newTestAnnotation("http://api.ft.com/things/71a5efa5-e6e0-3ce1-9190-a7eac8bef325", "isClassifiedBy")},
 			),
 			http.StatusOK,
 		},


### PR DESCRIPTION
As part of the platinum-ise annotations work, we have to remove suggestions from the v1 metadata publishing flow and convert them to annotations.