### PR TITLE
Mark as non-resilient, reduce severity

### DIFF
--- a/healthchecks.go
+++ b/healthchecks.go
@@ -48,7 +48,7 @@ func (h *HealthCheck) readQueueCheck() fthealth.Check {
 	return fthealth.Check{
 		ID:               "read-message-queue-proxy-reachable",
 		Name:             "Read Message Queue Proxy Reachable",
-		Severity:         1,
+		Severity:         2,
 		BusinessImpact:   "Annotations from published Next videos will not be created, clients will not see them within content.",
 		TechnicalSummary: "Read message queue proxy is not reachable/healthy",
 		PanicGuide:       h.panicGuide,
@@ -60,7 +60,7 @@ func (h *HealthCheck) writeQueueCheck() fthealth.Check {
 	return fthealth.Check{
 		ID:               "write-message-queue-proxy-reachable",
 		Name:             "Write Message Queue Proxy Reachable",
-		Severity:         1,
+		Severity:         2,
 		BusinessImpact:   "Annotations from published Next videos will not be created, clients will not see them within content.",
 		TechnicalSummary: "Write message queue proxy is not reachable/healthy",
 		PanicGuide:       h.panicGuide,

--- a/helm/upp-next-video-annotations-mapper/templates/service.yaml
+++ b/helm/upp-next-video-annotations-mapper/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     app: {{.Values.service.name}}
     visualize: "true" 
     hasHealthcheck: "{{ .Values.service.hasHealthcheck }}" 
+    isResilient: "{{ .Values.service.isResilient }}"
 spec:
   ports: 
     - port: 8080 

--- a/helm/upp-next-video-annotations-mapper/values.yaml
+++ b/helm/upp-next-video-annotations-mapper/values.yaml
@@ -4,6 +4,7 @@
 service:
   name: "" # The name of the service, should be defined in the specific app-configs folder.
   hasHealthcheck: "true"
+  isResilient: "false"
 replicaCount: 2
 image:
   repository: coco/upp-next-video-annotations-mapper


### PR DESCRIPTION
- mappers aren't resilient: both pods read from kafka using the same consumer group - this means only one of them is actually receiving the messages; if the pod which isn't receiving the messages stops, that's not problem, but if the pod who is actually receiving the messages stops working, then the other pod will not pick up messages either
- by marking it as non-resilient, the upp-aggregate-healthcheck (any versions which include this [PR](https://github.com/Financial-Times/upp-aggregate-healthcheck/pull/22)) will report the highest severity of any failed pods as the severity for the service 
- reduced the severity from 1 to 2 so any failures in this service will not turn dashing red