### PR TITLE
Adding logger to videoMapper

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -42,7 +42,6 @@ func (vm *videoMapper) mapNextVideoAnnotations() ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-
 	nextAnnsArray, err := getObjectsArrayField(annotationsField, vm.unmarshalled, videoUUID, vm)
 	if err != nil {
 		return nil, videoUUID, err

--- a/servicehandler.go
+++ b/servicehandler.go
@@ -25,7 +25,7 @@ func (h serviceHandler) mapRequest(w http.ResponseWriter, r *http.Request) {
 	}
 	tid := r.Header.Get("X-Request-Id")
 
-	vm := videoMapper{sc: h.sc, strContent: string(body), tid: tid}
+	vm := videoMapper{sc: h.sc, strContent: string(body), tid: tid, log: h.log}
 
 	mappedVideoBytes, _, err := h.mapNextVideoAnnotationsRequest(&vm)
 	if err != nil {


### PR DESCRIPTION
# Description

## What

Fixing the delete payload not propagating due to a runtime panic error from the service from a nil pointer dereference caused by the logger not being passed to the `videoMapper` object 

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3513

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
